### PR TITLE
Info Title and description as config values from json

### DIFF
--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -62,7 +62,22 @@ called `openapi-merge.json` by default, in your current directory. It should loo
       }
     }
   ],
-  "output": "./output.swagger.json"
+  "output": "./output.swagger.json",
+  "servers": [
+        {
+            "url": "https://{environment}.nxtbolt.in",
+            "description": "Hosted environment",
+            "variables": {
+                "environment": {
+                    "default": "dev-api",
+                    "enum": [
+                        "dev-api"
+                    ],
+                    "description": "dev environment"
+                }
+            }
+        }
+  ],
 }
 ```
 

--- a/packages/openapi-merge-cli/package.json
+++ b/packages/openapi-merge-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iouring-engineering/openapi-merge-cli",
-  "version": "1.3.6",
+  "version": "1.3.8",
   "description": "A cli tool for the openapi-merge library.",
   "keywords": [
     "openapi",

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -215,6 +215,8 @@ export type Configuration = {
    */
   inputs: ConfigurationInput[];
   servers: Swagger.Server[];
+  title: string;
+  description: string;
   /**
    * The output file to put the results in. If you use the .yml or .yaml extension then the schema will be output
    * in YAML format, otherwise, it will be output in JSON format.

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -214,9 +214,9 @@ export type Configuration = {
    * @examples require('./examples-for-schema.ts').ConfigurationInputExamples
    */
   inputs: ConfigurationInput[];
-  servers: Swagger.Server[];
-  title: string;
-  description: string;
+  servers?: Swagger.Server[];
+  title?: string;
+  description?: string;
   /**
    * The output file to put the results in. If you use the .yml or .yaml extension then the schema will be output
    * in YAML format, otherwise, it will be output in JSON format.

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -14,6 +14,7 @@ import fetch from 'isomorphic-fetch';
 import yaml from 'js-yaml';
 import { readFileAsString, readYamlOrJSON } from "./file-loading";
 import { serverConfiguration } from "./server-configuration";
+import { additionalInfoDescription, additionalInfoTitle } from "./info-configuration";
 
 const ERROR_LOADING_CONFIG = 1;
 const ERROR_LOADING_INPUTS = 2;
@@ -163,8 +164,14 @@ export async function main(): Promise<void> {
   }
 
   if (config.servers && config.servers.length > 0) {
-    mergeResult.output = serverConfiguration(mergeResult.output, config.servers)
+    mergeResult.output = serverConfiguration(mergeResult.output, config.servers);
   }
+
+
+  if (config.title)
+    mergeResult.output = additionalInfoTitle(mergeResult.output, config.title);
+  if (config.description)
+    mergeResult.output = additionalInfoDescription(mergeResult.output, config.description);
 
   const outputFullPath = path.join(basePath, config.output);
   logger.log(`## Inputs merged, writing the results out to '${outputFullPath}'`);

--- a/packages/openapi-merge-cli/src/info-configuration.ts
+++ b/packages/openapi-merge-cli/src/info-configuration.ts
@@ -1,0 +1,16 @@
+import { Swagger } from "atlassian-openapi";
+
+export function additionalInfoTitle(output: Swagger.SwaggerV3, title: string): Swagger.SwaggerV3 {
+    if(title && title !== ""){
+        output.info.title = title;
+    }
+    
+    return output;
+}
+
+export function additionalInfoDescription(output: Swagger.SwaggerV3, description: string): Swagger.SwaggerV3 {
+    if(description && description !== ""){
+        output.info.description = description;
+    }
+    return output;
+}


### PR DESCRIPTION
As an enhancement raised here [https://github.com/iouring-engineering/openapi-merge/issues/5](url)

Info Title and description as config values from json if it is exist or library will consider first openapi specification's title and description and write out into merged result specification.

